### PR TITLE
Fixed bug where handing in nil for these parameters could cut properties dictionary

### DIFF
--- a/Classes/Framework/Object Model/ReadmillUser.m
+++ b/Classes/Framework/Object Model/ReadmillUser.m
@@ -340,12 +340,11 @@
                   title:(NSString *)title 
                delegate:(id <ReadmillBookFindingDelegate>)bookfindingDelegate 
 {    
-    NSDictionary *properties = [NSDictionary dictionaryWithObjectsAndKeys:
-                                bookfindingDelegate, @"delegate",
-                                [NSThread currentThread], @"callbackThread",
-                                isbn, kReadmillAPIBookISBNKey, 
-                                title, kReadmillAPIBookTitleKey,
-                                nil];
+    NSMutableDictionary *properties = [NSMutableDictionary dictionary];
+    [properties setValue:bookfindingDelegate forKey:@"delegate"];
+    [properties setValue:[NSThread currentThread] forKey:@"callbackThread"];
+    [properties setValue:isbn forKey:kReadmillAPIBookISBNKey]; 
+    [properties setValue:title forKey:kReadmillAPIBookTitleKey];
     
     [self performSelectorInBackground:@selector(findBookWithProperties:)
                            withObject:properties];
@@ -356,14 +355,13 @@
                          author:(NSString *)author
                        delegate:(id <ReadmillBookFindingDelegate>)bookfindingDelegate 
 {
-    NSDictionary *properties = [NSDictionary dictionaryWithObjectsAndKeys:
-                                bookfindingDelegate, @"delegate",
-                                [NSThread currentThread], @"callbackThread",
-                                title, kReadmillAPIBookTitleKey,
-                                isbn, kReadmillAPIBookISBNKey, 
-                                author, kReadmillAPIBookAuthorKey,
-                                [NSNumber numberWithBool:YES], @"createIfNotFound",
-                                nil];
+    NSMutableDictionary *properties = [NSMutableDictionary dictionary];
+    [properties setValue:bookfindingDelegate forKey:@"delegate"];
+    [properties setValue:[NSThread currentThread] forKey:@"callbackThread"];
+    [properties setValue:[NSNumber numberWithBool:YES] forKey:@"createIfNotFound"];
+    [properties setValue:title forKey:kReadmillAPIBookTitleKey];
+    [properties setValue:isbn forKey:kReadmillAPIBookISBNKey];
+    [properties setValue:author forKey:kReadmillAPIBookAuthorKey];
     	
     [self performSelectorInBackground:@selector(findBookWithProperties:)
                            withObject:properties];
@@ -472,13 +470,12 @@
                    author:(NSString *)author
                  delegate:(id <ReadmillBookFindingDelegate>)bookfindingDelegate 
 {    
-    NSDictionary *properties = [NSDictionary dictionaryWithObjectsAndKeys:
-                                bookfindingDelegate, @"delegate",
-                                [NSThread currentThread], @"callbackThread",
-                                isbn, kReadmillAPIBookISBNKey, 
-                                title, kReadmillAPIBookTitleKey,
-                                author, kReadmillAPIBookAuthorKey,
-                                nil];
+    NSMutableDictionary *properties = [NSMutableDictionary dictionary];
+    [properties setValue:bookfindingDelegate forKey:@"delegate"];
+    [properties setValue:[NSThread currentThread] forKey:@"callbackThread"];
+    [properties setValue:isbn forKey:kReadmillAPIBookISBNKey]; 
+    [properties setValue:title forKey:kReadmillAPIBookTitleKey];
+    [properties setValue:author forKey:kReadmillAPIBookAuthorKey];
     
     [self performSelectorInBackground:@selector(createBookWithProperties:)
                            withObject:properties];


### PR DESCRIPTION
To better support the possibility of someone handing in nil as a
"title", "isbn" or "author", I recommend explicitly setting the keys and
values on the property dictionaries rather than using
"dictionaryWithObjectsAndKeys:".

I discovered this bug when I was handing in a nil ISBN since I didn't
have it when creating a book record. Since it was passed directly to
"dictionaryWithObjectsAndKeys:", then that method thought there were no
more keys or values and stopped processing them.
