### PR TITLE
Reading highlights

### DIFF
--- a/Classes/Framework/ReadmillAPIWrapper.h
+++ b/Classes/Framework/ReadmillAPIWrapper.h
@@ -602,6 +602,13 @@ The object returned here is appropriate for saving in a property list, NSUserDef
 - (void)highlightsForReadingWithId:(ReadmillReadingId)readingId completionHandler:(ReadmillAPICompletionHandler)completionHandler;
 
 /*!
+ @param readingId The id of the reading.
+ @param completionHandler A block that will return the result (id) and an error pointer.
+ @brief  Get all highlights for a particular reading in Readmill.
+ */
+- (ReadmillRequestOperation *)highlightsForReadingWithId:(ReadmillReadingId)readingId count:(NSUInteger)count fromDate:(NSDate *)fromDate toDate:(NSDate *)toDate completionHandler:(ReadmillAPICompletionHandler)completionHandler;
+
+/*!
  @param highlightId The id of the highlight.
  @param completionHandler A block that will return the result (id) and an error pointer.
  @brief  Deletes the particular highlight in Readmill.

--- a/Classes/Framework/ReadmillAPIWrapper.h
+++ b/Classes/Framework/ReadmillAPIWrapper.h
@@ -597,14 +597,17 @@ The object returned here is appropriate for saving in a property list, NSUserDef
 /*!
  @param readingId The id of the reading.
  @param completionHandler A block that will return the result (id) and an error pointer.
- @brief  Get all highlights for a particular reading in Readmill.
+ @brief  Get the first hundred highlights for a particular reading in Readmill.
  */
-- (void)highlightsForReadingWithId:(ReadmillReadingId)readingId completionHandler:(ReadmillAPICompletionHandler)completionHandler;
+- (ReadmillRequestOperation *)highlightsForReadingWithId:(ReadmillReadingId)readingId completionHandler:(ReadmillAPICompletionHandler)completionHandler;
 
 /*!
  @param readingId The id of the reading.
+ @param count Number of highlights to return.
+ @param fromDate Date to return highlights from.
+ @param toDate Date to return highlights to.
  @param completionHandler A block that will return the result (id) and an error pointer.
- @brief  Get all highlights for a particular reading in Readmill.
+ @brief  Get a specified number of highlights for a particular reading in Readmill between two dates.
  */
 - (ReadmillRequestOperation *)highlightsForReadingWithId:(ReadmillReadingId)readingId count:(NSUInteger)count fromDate:(NSDate *)fromDate toDate:(NSDate *)toDate completionHandler:(ReadmillAPICompletionHandler)completionHandler;
 

--- a/Classes/Framework/ReadmillAPIWrapper.m
+++ b/Classes/Framework/ReadmillAPIWrapper.m
@@ -727,6 +727,21 @@
                  completionHandler:completionHandler];
 }
 
+- (ReadmillRequestOperation *)highlightsForReadingWithId:(ReadmillReadingId)readingId count:(NSUInteger)count fromDate:(NSDate *)fromDate toDate:(NSDate *)toDate completionHandler:(ReadmillAPICompletionHandler)completionHandler
+{
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithCapacity:3];
+    [parameters setValue:@(count) forKey:@"count"];
+    [parameters setValue:@"highlighted_at" forKey:@"order"];
+    [parameters setValue:[fromDate stringWithRFC3339Format] forKey:@"from"];
+    [parameters setValue:[toDate stringWithRFC3339Format] forKey:@"to"];
+    
+    NSString *endpoint = [NSString stringWithFormat:@"%@/%d/highlights", [self readingsEndpoint], readingId];
+    return [self sendGetRequestToEndpoint:endpoint
+                           withParameters:parameters
+               shouldBeCalledUnauthorized:NO
+                        completionHandler:completionHandler];
+}
+
 - (void)deleteHighlightWithId:(NSUInteger)highlightId
             completionHandler:(ReadmillAPICompletionHandler)completionHandler
 {

--- a/Classes/Framework/ReadmillAPIWrapper.m
+++ b/Classes/Framework/ReadmillAPIWrapper.m
@@ -717,14 +717,10 @@
                   completionHandler:completionHandler];
 }
 
-- (void)highlightsForReadingWithId:(ReadmillReadingId)readingId
-                 completionHandler:(ReadmillAPICompletionHandler)completionHandler
+- (ReadmillRequestOperation *)highlightsForReadingWithId:(ReadmillReadingId)readingId
+                                       completionHandler:(ReadmillAPICompletionHandler)completionHandler
 {
-    NSString *endpoint = [NSString stringWithFormat:@"%@/%d/highlights", [self readingsEndpoint], readingId];
-    [self sendGetRequestToEndpoint:endpoint
-                    withParameters:@{ @"count" : @100 }
-        shouldBeCalledUnauthorized:NO
-                 completionHandler:completionHandler];
+    [self highlightsForReadingWithId:readingId count:100 fromDate:nil toDate:nil completionHandler:completionHandler];
 }
 
 - (ReadmillRequestOperation *)highlightsForReadingWithId:(ReadmillReadingId)readingId count:(NSUInteger)count fromDate:(NSDate *)fromDate toDate:(NSDate *)toDate completionHandler:(ReadmillAPICompletionHandler)completionHandler


### PR DESCRIPTION
Both methods for fetching reading highlights now return `ReadmillRequestOperation` so they can be cancelled easily.
